### PR TITLE
Struct keys vals

### DIFF
--- a/deepmerge.go
+++ b/deepmerge.go
@@ -146,7 +146,11 @@ func translateRecursive(copy, original reflect.Value) {
 	// If it is a struct we translate each field
 	case reflect.Struct:
 		for i := 0; i < original.NumField(); i += 1 {
-			translateRecursive(copy.Field(i), original.Field(i))
+			if copy.Field(i).CanSet() {
+				translateRecursive(copy.Field(i), original.Field(i))
+			} else {
+				fmt.Printf("WARNING: Cannot Set unexported fields. Type:%T ,Value:%v will be set to it's zero value.\n", original.Type().Field(i).Name, original.Field(i))
+			}
 		}
 
 	// If it is a slice we create a new slice and translate each element

--- a/deepmerge_test.go
+++ b/deepmerge_test.go
@@ -280,3 +280,88 @@ func Test_use_import_strings_Join(t *testing.T) {
 	assert.Equal(t, expect, got)
 	assert.Nil(t, err)
 }
+
+func Test_struct_key_update_value(t *testing.T) {
+	type mystruct struct {
+		firstName string
+		lastName  string
+	}
+
+	k1 := mystruct{
+		firstName: "John",
+		lastName:  "Doe",
+	}
+
+	map1 := map[mystruct]bool{
+		k1: false,
+	}
+
+	map2 := map[mystruct]bool{
+		k1: true,
+	}
+
+	expect := map[mystruct]bool{
+		k1: true,
+	}
+
+	f := func(a, b bool) bool { return b }
+
+	d := &DeepMerge{}
+	got, err := d.Merge(map1, map2, &f)
+	assert.Equal(t, expect, got)
+	assert.Nil(t, err)
+}
+
+func Test_update_struct_vals(t *testing.T) {
+	type person struct {
+		firstName string
+		lastName  string
+	}
+
+	type details struct {
+		Age     int
+		Address string
+	}
+
+	k1 := person{
+		firstName: "John",
+		lastName:  "Doe",
+	}
+
+	v1 := details{
+		Age:     23,
+		Address: "1 anywhere Ln, CA, 12342",
+	}
+
+	v2 := details{
+		Age:     32,
+		Address: "199 somewhere over the rainbow, MA 4212",
+	}
+
+	map1 := map[person]details{
+		k1: v1,
+	}
+
+	map2 := map[person]details{
+		k1: v2,
+	}
+
+	expect := map[person]details{
+		k1: details{
+			Age:     v1.Age,
+			Address: v2.Address,
+		},
+	}
+
+	f := func(a, b details) details {
+		return details{
+			Age:     a.Age,
+			Address: b.Address,
+		}
+	}
+
+	d := &DeepMerge{}
+	got, err := d.Merge(map1, map2, &f)
+	assert.Equal(t, expect, got)
+	assert.Nil(t, err)
+}

--- a/deepmerge_test.go
+++ b/deepmerge_test.go
@@ -319,7 +319,7 @@ func Test_update_struct_exported_fields(t *testing.T) {
 	}
 
 	// Only exported fields can be modified
-	// unexported fields are set to their Zero value
+	// unexported fields are set to their zero value
 	type details struct {
 		ssn     string
 		Age     int

--- a/deepmerge_test.go
+++ b/deepmerge_test.go
@@ -312,13 +312,16 @@ func Test_struct_key_update_value(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_update_struct_vals(t *testing.T) {
+func Test_update_struct_exported_fields(t *testing.T) {
 	type person struct {
 		firstName string
 		lastName  string
 	}
 
+	// Only exported fields can be modified
+	// unexported fields are set to their Zero value
 	type details struct {
+		ssn     string
 		Age     int
 		Address string
 	}
@@ -331,11 +334,13 @@ func Test_update_struct_vals(t *testing.T) {
 	v1 := details{
 		Age:     23,
 		Address: "1 anywhere Ln, CA, 12342",
+		ssn:     "111-111-1111",
 	}
 
 	v2 := details{
 		Age:     32,
 		Address: "199 somewhere over the rainbow, MA 4212",
+		ssn:     "222-222-2222",
 	}
 
 	map1 := map[person]details{
@@ -350,6 +355,7 @@ func Test_update_struct_vals(t *testing.T) {
 		k1: details{
 			Age:     v1.Age,
 			Address: v2.Address,
+			ssn:     "",
 		},
 	}
 
@@ -362,6 +368,7 @@ func Test_update_struct_vals(t *testing.T) {
 
 	d := &DeepMerge{}
 	got, err := d.Merge(map1, map2, &f)
+	t.Log(got)
 	assert.Equal(t, expect, got)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Handle cases when keys and vals are structs. Since we can't `Set` on unexported fields in structs, we'll ignore those fields rather than `panic`ing. It will set those unexported fields to it's zero value. Granted this is not ideal but since we're not modifying the actual input, it's probably OK.