### PR TITLE
Refactor to include maps in the init struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Typical usage:
 	}
 
     add := func(a, b int) int { return a + b }
-    d := &DeepMerge{}
-    mergedMap, err := d.Merge(map1, map2, &add)
+    d := &DeepMerge{
+         map1: map1,
+         map2: map2,
+    }
+    mergedMap, err := d.Merge(&add)
 ```
 
 Expected Output(`mergedMap`):

--- a/deepmerge.go
+++ b/deepmerge.go
@@ -8,6 +8,9 @@ import (
 
 // DeepMerge instantiates initial counters / keys for traversal
 type DeepMerge struct {
+	map1 interface{}
+	map2 interface{}
+
 	// Stores the keys that we have processed as we iterate the maps
 	seenKeys map[interface{}]bool
 
@@ -16,26 +19,28 @@ type DeepMerge struct {
 }
 
 // Merge merges 2 maps by applying a fptr (function pointer) to the values
-// Example: Merge(map1, map2, &my_func)
+// Example:
+// d := &DeepMerge{ map1 : some_map1, map2: some_map2}
+// d.Merge(&my_func)
 // where my_func := func(a,b int) int { return a + b }
-func (d DeepMerge) Merge(m1, m2, fptr interface{}) (interface{}, error) {
+func (d DeepMerge) Merge(fptr interface{}) (interface{}, error) {
 
-	if m1 == nil && m2 != nil {
-		return m2, nil
+	if d.map1 == nil && d.map2 != nil {
+		return d.map2, nil
 	}
 
-	if m1 != nil && m2 == nil {
-		return m1, nil
+	if d.map1 != nil && d.map2 == nil {
+		return d.map1, nil
 	}
 
-	m1_t := reflect.ValueOf(m1).Type()
-	m2_t := reflect.ValueOf(m2).Type()
+	m1_t := reflect.ValueOf(d.map1).Type()
+	m2_t := reflect.ValueOf(d.map2).Type()
 	if m1_t != m2_t {
 		return nil, errors.New("Maps have to be of the same type")
 	}
 
 	d.seenKeys = make(map[interface{}]bool)
-	return d.merge(m1, m2, fptr), nil
+	return d.merge(d.map1, d.map2, fptr), nil
 }
 
 func (d DeepMerge) merge(m1, m2, fptr interface{}) interface{} {

--- a/deepmerge_test.go
+++ b/deepmerge_test.go
@@ -16,8 +16,12 @@ func Test_map1_is_nil(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, err := d.Merge(nil, map2, &sub)
+
+	d := &DeepMerge{
+		map1: nil,
+		map2: map2,
+	}
+	got, err := d.Merge(&sub)
 	assert.Equal(t, got, map2)
 	assert.Nil(t, err)
 }
@@ -31,8 +35,13 @@ func Test_map2_is_nil(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, nil, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: nil,
+	}
+
+	got, err := d.Merge(&sub)
 	assert.Equal(t, got, map1)
 	assert.Nil(t, err)
 }
@@ -51,8 +60,13 @@ func Test_fptr_is_basic_update(t *testing.T) {
 		"c": 22,
 	}
 	fp := func(a, b int) int { return b }
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, map2, &fp)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, err := d.Merge(&fp)
 	assert.Equal(t, got, map2)
 	assert.Nil(t, err)
 }
@@ -71,8 +85,13 @@ func Test_maps_are_not_the_same_type(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, map2, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, err := d.Merge(&sub)
 	assert.Nil(t, got)
 	assert.Error(t, err)
 }
@@ -97,8 +116,13 @@ func Test_basicAddition_depth1(t *testing.T) {
 	}
 
 	add := func(a, b int) int { return a + b }
-	d := &DeepMerge{}
-	got, _ := d.Merge(map1, map2, &add)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, _ := d.Merge(&add)
 	assert.Equal(t, expect, got)
 }
 
@@ -122,8 +146,13 @@ func Test_basicsubtraction_depth1(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, _ := d.Merge(map1, map2, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, _ := d.Merge(&sub)
 	assert.Equal(t, expect, got)
 }
 
@@ -148,8 +177,13 @@ func Test_basicsubtraction_nested(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, _ := d.Merge(map1, map2, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, _ := d.Merge(&sub)
 	assert.Equal(t, expect, got)
 }
 
@@ -170,8 +204,13 @@ func Test_nested_map1_missing_key(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, _ := d.Merge(map1, map2, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, _ := d.Merge(&sub)
 	assert.Equal(t, expect, got)
 }
 func Test_nested_both_maps_missing_key(t *testing.T) {
@@ -193,8 +232,13 @@ func Test_nested_both_maps_missing_key(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, _ := d.Merge(map1, map2, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, _ := d.Merge(&sub)
 	assert.Equal(t, expect, got)
 }
 
@@ -218,8 +262,13 @@ func Test_nested_same_sub_keys(t *testing.T) {
 	}
 
 	sub := func(a, b int) int { return a - b }
-	d := &DeepMerge{}
-	got, _ := d.Merge(map1, map2, &sub)
+
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, _ := d.Merge(&sub)
 	assert.Equal(t, expect, got)
 }
 
@@ -244,8 +293,12 @@ func Test_string_prefix(t *testing.T) {
 	}
 
 	f := func(a, b string) string { return b + "_" + a }
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, map2, &f)
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, err := d.Merge(&f)
 	assert.Equal(t, expect, got)
 	assert.Nil(t, err)
 }
@@ -275,8 +328,12 @@ func Test_use_import_strings_Join(t *testing.T) {
 		return strings.Join(s, "++")
 	}
 
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, map2, &f)
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, err := d.Merge(&f)
 	assert.Equal(t, expect, got)
 	assert.Nil(t, err)
 }
@@ -306,8 +363,12 @@ func Test_struct_key_update_value(t *testing.T) {
 
 	f := func(a, b bool) bool { return b }
 
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, map2, &f)
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, err := d.Merge(&f)
 	assert.Equal(t, expect, got)
 	assert.Nil(t, err)
 }
@@ -366,8 +427,12 @@ func Test_update_struct_exported_fields(t *testing.T) {
 		}
 	}
 
-	d := &DeepMerge{}
-	got, err := d.Merge(map1, map2, &f)
+	d := &DeepMerge{
+		map1: map1,
+		map2: map2,
+	}
+
+	got, err := d.Merge(&f)
 	t.Log(got)
 	assert.Equal(t, expect, got)
 	assert.Nil(t, err)
@@ -388,8 +453,11 @@ func Benchmark_depth1_maps(b *testing.B) {
 		}
 
 		add := func(a, b int) int { return a + b }
-		d := &DeepMerge{}
-		_, _ = d.Merge(map1, map2, &add)
+		d := &DeepMerge{
+			map1: map1,
+			map2: map2,
+		}
+		_, _ = d.Merge(&add)
 	}
 }
 
@@ -409,8 +477,11 @@ func Benchmark_nested_maps(b *testing.B) {
 		}
 
 		add := func(a, b int) int { return a + b }
-		d := &DeepMerge{}
-		_, _ = d.Merge(map1, map2, &add)
+		d := &DeepMerge{
+			map1: map1,
+			map2: map2,
+		}
+		_, _ = d.Merge(&add)
 	}
 }
 
@@ -457,7 +528,10 @@ func Benchmark_struct(b *testing.B) {
 				Address: a.Address,
 			}
 		}
-		d := &DeepMerge{}
-		_, _ = d.Merge(map1, map2, &add)
+		d := &DeepMerge{
+			map1: map1,
+			map2: map2,
+		}
+		_, _ = d.Merge(&add)
 	}
 }


### PR DESCRIPTION
Refactor the method to take the input maps as part of the struct . Simplifies the call to Merge.

/cc @WillAbides since you suggested this.